### PR TITLE
rac service pool

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -97,9 +97,6 @@ dependencies {
 
 	implementation("org.awaitility", "awaitility", "4.3.0")
 
-	implementation("org.springframework.boot:spring-boot-starter-cache")
-	implementation("com.github.ben-manes.caffeine:caffeine")
-
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -97,6 +97,9 @@ dependencies {
 
 	implementation("org.awaitility", "awaitility", "4.3.0")
 
+	implementation("org.springframework.boot:spring-boot-starter-cache")
+	implementation("com.github.ben-manes.caffeine:caffeine")
+
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 }
 

--- a/src/main/java/ru/digilabs/alkir/rahc/RahcApplication.java
+++ b/src/main/java/ru/digilabs/alkir/rahc/RahcApplication.java
@@ -8,6 +8,7 @@ import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.scheduling.annotation.EnableScheduling;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Unmatched;
@@ -22,6 +23,7 @@ import java.util.regex.Pattern;
 
 @SpringBootApplication
 @ConfigurationPropertiesScan
+@EnableScheduling
 @RequiredArgsConstructor
 @Command(
     name = "rahc",

--- a/src/main/java/ru/digilabs/alkir/rahc/aop/WebRetrayableRacMethodExceptionHandler.java
+++ b/src/main/java/ru/digilabs/alkir/rahc/aop/WebRetrayableRacMethodExceptionHandler.java
@@ -1,7 +1,11 @@
 package ru.digilabs.alkir.rahc.aop;
 
 import lombok.SneakyThrows;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
 
+@Component
+@Profile("web")
 public class WebRetrayableRacMethodExceptionHandler implements RetrayableRacMethodExceptionHandler {
     @Override
     @SneakyThrows

--- a/src/main/java/ru/digilabs/alkir/rahc/service/RacServicePool.java
+++ b/src/main/java/ru/digilabs/alkir/rahc/service/RacServicePool.java
@@ -17,6 +17,8 @@ import java.time.Instant;
 import java.util.HexFormat;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -61,6 +63,7 @@ public class RacServicePool {
         var pooled = pool.compute(key, (k, existing) -> {
             if (existing != null && !existing.isExpired(now, ttlSeconds)) {
                 existing.updateLastAccess(now);
+                existing.acquire();
                 LOGGER.debug("Reusing pooled RacService for key: {}", k);
                 return existing;
             }
@@ -68,16 +71,18 @@ public class RacServicePool {
             // Закрываем старое соединение если есть
             if (existing != null) {
                 LOGGER.debug("Closing expired RacService for key: {}", k);
-                existing.closeQuietly();
+                existing.requestClose();
             }
 
             LOGGER.debug("Creating new RacService for key: {}", k);
             var configurationProperties = connection.toConfigurationProperties();
             var racService = racServiceObjectProvider.getObject(configurationProperties, factory);
-            return new PooledRacService(racService, now);
+            var created = new PooledRacService(racService, now);
+            created.acquire();
+            return created;
         });
 
-        return new PooledRacServiceWrapper(pooled.getRacService());
+        return new PooledRacServiceWrapper(pooled);
     }
 
     /**
@@ -88,7 +93,7 @@ public class RacServicePool {
         var removed = pool.remove(key);
         if (removed != null) {
             LOGGER.debug("Invalidating RacService for key: {}", key);
-            removed.closeQuietly();
+            removed.requestClose();
         }
     }
 
@@ -107,7 +112,7 @@ public class RacServicePool {
             var entry = iterator.next();
             if (entry.getValue().isExpired(now, ttlSeconds)) {
                 LOGGER.debug("Removing expired RacService for key: {}", entry.getKey());
-                entry.getValue().closeQuietly();
+                entry.getValue().requestClose();
                 iterator.remove();
                 expiredCount++;
             }
@@ -141,7 +146,7 @@ public class RacServicePool {
         var removed = pool.remove(oldest.getKey());
         if (removed != null) {
             LOGGER.debug("Evicting oldest RacService for key: {}", oldest.getKey());
-            removed.closeQuietly();
+            removed.requestClose();
             return true;
         }
 
@@ -175,6 +180,9 @@ public class RacServicePool {
     private static class PooledRacService {
         private final RacService racService;
         private volatile Instant lastAccess;
+        private final AtomicInteger activeUsages = new AtomicInteger(0);
+        private final AtomicBoolean closeRequested = new AtomicBoolean(false);
+        private final AtomicBoolean closed = new AtomicBoolean(false);
 
         PooledRacService(RacService racService, Instant createdAt) {
             this.racService = racService;
@@ -193,11 +201,39 @@ public class RacServicePool {
             this.lastAccess = time;
         }
 
+        void acquire() {
+            activeUsages.incrementAndGet();
+        }
+
+        void release() {
+            var usages = activeUsages.decrementAndGet();
+            if (usages < 0) {
+                activeUsages.incrementAndGet();
+                LOGGER.warn("Detected extra release() call for pooled RacService");
+                return;
+            }
+
+            if (usages == 0 && closeRequested.get()) {
+                closeQuietly();
+            }
+        }
+
         boolean isExpired(Instant now, long ttlSeconds) {
             return lastAccess.plusSeconds(ttlSeconds).isBefore(now);
         }
 
+        void requestClose() {
+            closeRequested.set(true);
+            if (activeUsages.get() == 0) {
+                closeQuietly();
+            }
+        }
+
         void closeQuietly() {
+            if (!closed.compareAndSet(false, true)) {
+                return;
+            }
+
             try {
                 racService.close();
             } catch (Exception e) {
@@ -216,16 +252,21 @@ public class RacServicePool {
     // Долгосрочно лучше выделить интерфейс для RacService или использовать proxy.
     private static final class PooledRacServiceWrapper extends RacService {
 
+        private final PooledRacService pooled;
         private final RacService delegate;
+        private final AtomicBoolean released = new AtomicBoolean(false);
 
-        PooledRacServiceWrapper(RacService delegate) {
+        PooledRacServiceWrapper(PooledRacService pooled) {
             super(null, null);
-            this.delegate = delegate;
+            this.pooled = pooled;
+            this.delegate = pooled.getRacService();
         }
 
         @Override
         public void close() {
-            // Не закрываем - соединение остаётся в пуле
+            if (released.compareAndSet(false, true)) {
+                pooled.release();
+            }
         }
 
         @Override

--- a/src/main/java/ru/digilabs/alkir/rahc/service/RacServicePool.java
+++ b/src/main/java/ru/digilabs/alkir/rahc/service/RacServicePool.java
@@ -76,11 +76,11 @@ public class RacServicePool {
             LOGGER.debug("Creating new RacService for key: {}", key);
             var racService = racServiceObjectProvider.getObject(configurationProperties, factory);
             var created = new PooledRacService(racService, now);
-            created.acquire();
 
             if (existing == null) {
                 var winner = pool.putIfAbsent(key, created);
                 if (winner == null) {
+                    created.acquire();
                     return new PooledRacServiceWrapper(created);
                 }
 
@@ -91,6 +91,7 @@ public class RacServicePool {
             if (pool.replace(key, existing, created)) {
                 LOGGER.debug("Closing expired RacService for key: {}", key);
                 existing.requestClose();
+                created.acquire();
                 return new PooledRacServiceWrapper(created);
             }
 
@@ -125,8 +126,8 @@ public class RacServicePool {
             var entry = iterator.next();
             if (entry.getValue().isExpired(now, ttlSeconds)) {
                 LOGGER.debug("Removing expired RacService for key: {}", entry.getKey());
-                entry.getValue().requestClose();
                 iterator.remove();
+                entry.getValue().requestClose();
                 expiredCount++;
             }
         }
@@ -149,17 +150,20 @@ public class RacServicePool {
 
     private boolean evictOldest() {
         var oldest = pool.entrySet().stream()
-            .min((e1, e2) -> e1.getValue().getLastAccess().compareTo(e2.getValue().getLastAccess()))
+            .min(java.util.Comparator
+                .<Map.Entry<String, PooledRacService>>comparingInt(e -> e.getValue().isIdle() ? 0 : 1)
+                .thenComparing(e -> e.getValue().getLastAccess()))
             .orElse(null);
 
         if (oldest == null) {
             return false;
         }
 
-        var removed = pool.remove(oldest.getKey());
-        if (removed != null) {
+        var key = oldest.getKey();
+        var target = oldest.getValue();
+        if (pool.remove(key, target)) {
             LOGGER.debug("Evicting oldest RacService for key: {}", oldest.getKey());
-            removed.requestClose();
+            target.requestClose();
             return true;
         }
 
@@ -216,6 +220,10 @@ public class RacServicePool {
 
         void acquire() {
             activeUsages.incrementAndGet();
+        }
+
+        boolean isIdle() {
+            return activeUsages.get() == 0;
         }
 
         void release() {

--- a/src/main/java/ru/digilabs/alkir/rahc/service/RacServicePool.java
+++ b/src/main/java/ru/digilabs/alkir/rahc/service/RacServicePool.java
@@ -1,0 +1,344 @@
+package ru.digilabs.alkir.rahc.service;
+
+import com._1c.v8.ibis.admin.client.IAgentAdminConnectorFactory;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import ru.digilabs.alkir.rahc.configuration.RasConfigurationProperties;
+import ru.digilabs.alkir.rahc.dto.ConnectionDTO;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Пул соединений RacService с кэшированием по ключу (address:port).
+ * Позволяет переиспользовать соединения между HTTP-запросами,
+ * избегая накладных расходов на установление соединения и аутентификацию.
+ */
+@Service
+@Slf4j
+public class RacServicePool {
+
+    private final ObjectProvider<RacService> racServiceObjectProvider;
+    private final IAgentAdminConnectorFactory factory;
+
+    private final Map<String, PooledRacService> pool = new ConcurrentHashMap<>();
+
+    @Value("${rac.pool.ttl-seconds:300}")
+    private long ttlSeconds;
+
+    @Value("${rac.pool.max-size:100}")
+    private int maxPoolSize;
+
+    public RacServicePool(
+        @Qualifier("racService") ObjectProvider<RacService> racServiceObjectProvider,
+        IAgentAdminConnectorFactory factory
+    ) {
+        this.racServiceObjectProvider = racServiceObjectProvider;
+        this.factory = factory;
+    }
+
+    /**
+     * Получает RacService из пула или создаёт новый.
+     * Возвращает обёртку PooledRacServiceWrapper, которая при close() не закрывает соединение,
+     * а возвращает его в пул.
+     */
+    public RacService getRacService(ConnectionDTO connection) {
+        var key = buildKey(connection);
+        var now = Instant.now();
+
+        var pooled = pool.compute(key, (k, existing) -> {
+            if (existing != null && !existing.isExpired(now, ttlSeconds)) {
+                existing.updateLastAccess(now);
+                LOGGER.debug("Reusing pooled RacService for key: {}", k);
+                return existing;
+            }
+
+            // Закрываем старое соединение если есть
+            if (existing != null) {
+                LOGGER.debug("Closing expired RacService for key: {}", k);
+                existing.closeQuietly();
+            }
+
+            // Проверяем размер пула
+            if (pool.size() >= maxPoolSize) {
+                evictOldest();
+            }
+
+            LOGGER.debug("Creating new RacService for key: {}", k);
+            var configurationProperties = connection.toConfigurationProperties();
+            var racService = racServiceObjectProvider.getObject(configurationProperties, factory);
+            return new PooledRacService(racService, now);
+        });
+
+        return new PooledRacServiceWrapper(pooled.getRacService());
+    }
+
+    /**
+     * Удаляет соединение из пула (например, при ошибке).
+     */
+    public void invalidate(ConnectionDTO connection) {
+        var key = buildKey(connection);
+        var removed = pool.remove(key);
+        if (removed != null) {
+            LOGGER.debug("Invalidating RacService for key: {}", key);
+            removed.closeQuietly();
+        }
+    }
+
+    /**
+     * Периодическая очистка устаревших соединений.
+     */
+    @Scheduled(fixedDelayString = "${rac.pool.cleanup-interval-ms:60000}")
+    public void cleanupExpired() {
+        var now = Instant.now();
+        var expiredCount = 0;
+
+        var iterator = pool.entrySet().iterator();
+        while (iterator.hasNext()) {
+            var entry = iterator.next();
+            if (entry.getValue().isExpired(now, ttlSeconds)) {
+                LOGGER.debug("Removing expired RacService for key: {}", entry.getKey());
+                entry.getValue().closeQuietly();
+                iterator.remove();
+                expiredCount++;
+            }
+        }
+
+        if (expiredCount > 0) {
+            LOGGER.info("Cleaned up {} expired RacService connections. Pool size: {}", expiredCount, pool.size());
+        }
+    }
+
+    /**
+     * Вытесняет самое старое соединение из пула.
+     */
+    private void evictOldest() {
+        var oldest = pool.entrySet().stream()
+            .min((e1, e2) -> e1.getValue().getLastAccess().compareTo(e2.getValue().getLastAccess()))
+            .orElse(null);
+
+        if (oldest != null) {
+            LOGGER.debug("Evicting oldest RacService for key: {}", oldest.getKey());
+            pool.remove(oldest.getKey());
+            oldest.getValue().closeQuietly();
+        }
+    }
+
+    private String buildKey(ConnectionDTO connection) {
+        var props = connection.toConfigurationProperties();
+        return props.getAddress() + ":" + props.getPort() + ":" +
+            props.getClusterAdminUsername() + ":" + props.getClusterAdminPassword();
+    }
+
+    public int getPoolSize() {
+        return pool.size();
+    }
+
+    /**
+     * Внутренний класс для хранения RacService с метаданными.
+     */
+    private static class PooledRacService {
+        private final RacService racService;
+        private Instant lastAccess;
+
+        PooledRacService(RacService racService, Instant createdAt) {
+            this.racService = racService;
+            this.lastAccess = createdAt;
+        }
+
+        RacService getRacService() {
+            return racService;
+        }
+
+        Instant getLastAccess() {
+            return lastAccess;
+        }
+
+        void updateLastAccess(Instant time) {
+            this.lastAccess = time;
+        }
+
+        boolean isExpired(Instant now, long ttlSeconds) {
+            return lastAccess.plusSeconds(ttlSeconds).isBefore(now);
+        }
+
+        void closeQuietly() {
+            try {
+                racService.close();
+            } catch (Exception e) {
+                LOGGER.warn("Error closing RacService", e);
+            }
+        }
+
+        private static final org.slf4j.Logger LOGGER = org.slf4j.LoggerFactory.getLogger(PooledRacService.class);
+    }
+
+    /**
+     * Обёртка над RacService, которая при close() не закрывает реальное соединение.
+     */
+    private static class PooledRacServiceWrapper extends RacService {
+
+        private final RacService delegate;
+
+        PooledRacServiceWrapper(RacService delegate) {
+            super(null, null);
+            this.delegate = delegate;
+        }
+
+        @Override
+        public void close() {
+            // Не закрываем - соединение остаётся в пуле
+        }
+
+        @Override
+        public void init() {
+            // Не инициализируем - используем делегат
+        }
+
+        // Делегируем все методы к реальному RacService
+        @Override
+        public java.util.UUID getClusterId(ConnectionDTO connection) {
+            return delegate.getClusterId(connection);
+        }
+
+        @Override
+        public java.util.UUID getIbId(ConnectionDTO connection) {
+            return delegate.getIbId(connection);
+        }
+
+        @Override
+        public java.util.List<com._1c.v8.ibis.admin.IClusterInfo> getClusters() {
+            return delegate.getClusters();
+        }
+
+        @Override
+        public com._1c.v8.ibis.admin.IClusterInfo getClusterInfo(java.util.UUID clusterId) {
+            return delegate.getClusterInfo(clusterId);
+        }
+
+        @Override
+        public java.util.UUID editCluster(com._1c.v8.ibis.admin.IClusterInfo clusterInfo) {
+            return delegate.editCluster(clusterInfo);
+        }
+
+        @Override
+        public void deleteCluster(java.util.UUID clusterId) {
+            delegate.deleteCluster(clusterId);
+        }
+
+        @Override
+        public java.util.List<com._1c.v8.ibis.admin.IClusterManagerInfo> getClusterManagers(java.util.UUID clusterId) {
+            return delegate.getClusterManagers(clusterId);
+        }
+
+        @Override
+        public com._1c.v8.ibis.admin.IClusterManagerInfo getClusterManagerInfo(java.util.UUID clusterId, java.util.UUID managerId) {
+            return delegate.getClusterManagerInfo(clusterId, managerId);
+        }
+
+        @Override
+        public java.util.List<com._1c.v8.ibis.admin.IClusterServiceInfo> getClusterServices(java.util.UUID clusterId) {
+            return delegate.getClusterServices(clusterId);
+        }
+
+        @Override
+        public java.util.List<com._1c.v8.ibis.admin.IClusterServiceInfo> getClusterServices(java.util.UUID clusterId, java.util.UUID managerId) {
+            return delegate.getClusterServices(clusterId, managerId);
+        }
+
+        @Override
+        public java.util.List<com._1c.v8.ibis.admin.IInfoBaseInfo> getInfoBasesFull(java.util.UUID clusterId) {
+            return delegate.getInfoBasesFull(clusterId);
+        }
+
+        @Override
+        public java.util.List<com._1c.v8.ibis.admin.IInfoBaseInfoShort> getInfoBases(java.util.UUID clusterId) {
+            return delegate.getInfoBases(clusterId);
+        }
+
+        @Override
+        public com._1c.v8.ibis.admin.IInfoBaseInfoShort getInfoBase(java.util.UUID clusterId, java.util.UUID ibId) {
+            return delegate.getInfoBase(clusterId, ibId);
+        }
+
+        @Override
+        public com._1c.v8.ibis.admin.IInfoBaseInfo getInfoBaseFull(java.util.UUID clusterId, java.util.UUID ibId, java.util.Optional<String> ibUsername, java.util.Optional<String> ibPassword) {
+            return delegate.getInfoBaseFull(clusterId, ibId, ibUsername, ibPassword);
+        }
+
+        @Override
+        public void updateInfoBase(java.util.UUID clusterId, com._1c.v8.ibis.admin.IInfoBaseInfo ibInfo, java.util.Optional<String> ibUsername, java.util.Optional<String> ibPassword) {
+            delegate.updateInfoBase(clusterId, ibInfo, ibUsername, ibPassword);
+        }
+
+        @Override
+        public java.util.UUID createInfoBase(java.util.UUID clusterId, com._1c.v8.ibis.admin.IInfoBaseInfo ibInfo, int mode) {
+            return delegate.createInfoBase(clusterId, ibInfo, mode);
+        }
+
+        @Override
+        public java.util.List<com._1c.v8.ibis.admin.ISessionInfo> getSessions(java.util.UUID clusterId) {
+            return delegate.getSessions(clusterId);
+        }
+
+        @Override
+        public java.util.List<com._1c.v8.ibis.admin.ISessionInfo> getSessions(java.util.UUID clusterId, java.util.UUID ibId) {
+            return delegate.getSessions(clusterId, ibId);
+        }
+
+        @Override
+        public com._1c.v8.ibis.admin.ISessionInfo getSessionInfo(java.util.UUID clusterId, java.util.UUID sid) {
+            return delegate.getSessionInfo(clusterId, sid);
+        }
+
+        @Override
+        public void terminateSession(java.util.UUID clusterId, java.util.UUID sid, java.util.Optional<String> message) {
+            delegate.terminateSession(clusterId, sid, message);
+        }
+
+        @Override
+        public java.util.List<com._1c.v8.ibis.admin.IWorkingServerInfo> getWorkingServers(java.util.UUID clusterId) {
+            return delegate.getWorkingServers(clusterId);
+        }
+
+        @Override
+        public com._1c.v8.ibis.admin.IWorkingServerInfo getWorkingServer(java.util.UUID clusterId, java.util.UUID serverId) {
+            return delegate.getWorkingServer(clusterId, serverId);
+        }
+
+        @Override
+        public java.util.UUID editWorkingServer(java.util.UUID clusterId, com._1c.v8.ibis.admin.IWorkingServerInfo serverInfo) {
+            return delegate.editWorkingServer(clusterId, serverInfo);
+        }
+
+        @Override
+        public void deleteWorkingServer(java.util.UUID clusterId, java.util.UUID serverId) {
+            delegate.deleteWorkingServer(clusterId, serverId);
+        }
+
+        @Override
+        public java.util.List<com._1c.v8.ibis.admin.IWorkingProcessInfo> getWorkingProcesses(java.util.UUID clusterId) {
+            return delegate.getWorkingProcesses(clusterId);
+        }
+
+        @Override
+        public com._1c.v8.ibis.admin.IWorkingProcessInfo getWorkingProcess(java.util.UUID clusterId, java.util.UUID processId) {
+            return delegate.getWorkingProcess(clusterId, processId);
+        }
+
+        @Override
+        public java.util.List<com._1c.v8.ibis.admin.IWorkingProcessInfo> getServerWorkingProcesses(java.util.UUID clusterId, java.util.UUID serverId) {
+            return delegate.getServerWorkingProcesses(clusterId, serverId);
+        }
+
+        @Override
+        public java.util.List<com._1c.v8.ibis.admin.IClusterManagerInfo> getServerClusterManagers(java.util.UUID clusterId, java.util.UUID serverId) {
+            return delegate.getServerClusterManagers(clusterId, serverId);
+        }
+    }
+}

--- a/src/main/java/ru/digilabs/alkir/rahc/service/RacServicePool.java
+++ b/src/main/java/ru/digilabs/alkir/rahc/service/RacServicePool.java
@@ -56,33 +56,46 @@ public class RacServicePool {
      */
     public RacService getRacService(ConnectionDTO connection) {
         var key = buildKey(connection);
-        var now = Instant.now();
+        var configurationProperties = connection.toConfigurationProperties();
 
-        evictIfPoolIsFullForNewKey(key);
+        while (true) {
+            var now = Instant.now();
+            var existing = pool.get(key);
 
-        var pooled = pool.compute(key, (k, existing) -> {
             if (existing != null && !existing.isExpired(now, ttlSeconds)) {
                 existing.updateLastAccess(now);
                 existing.acquire();
-                LOGGER.debug("Reusing pooled RacService for key: {}", k);
-                return existing;
+                LOGGER.debug("Reusing pooled RacService for key: {}", key);
+                return new PooledRacServiceWrapper(existing);
             }
 
-            // Закрываем старое соединение если есть
-            if (existing != null) {
-                LOGGER.debug("Closing expired RacService for key: {}", k);
-                existing.requestClose();
+            if (existing == null) {
+                evictIfPoolIsFullForNewKey(key);
             }
 
-            LOGGER.debug("Creating new RacService for key: {}", k);
-            var configurationProperties = connection.toConfigurationProperties();
+            LOGGER.debug("Creating new RacService for key: {}", key);
             var racService = racServiceObjectProvider.getObject(configurationProperties, factory);
             var created = new PooledRacService(racService, now);
             created.acquire();
-            return created;
-        });
 
-        return new PooledRacServiceWrapper(pooled);
+            if (existing == null) {
+                var winner = pool.putIfAbsent(key, created);
+                if (winner == null) {
+                    return new PooledRacServiceWrapper(created);
+                }
+
+                created.requestClose();
+                continue;
+            }
+
+            if (pool.replace(key, existing, created)) {
+                LOGGER.debug("Closing expired RacService for key: {}", key);
+                existing.requestClose();
+                return new PooledRacServiceWrapper(created);
+            }
+
+            created.requestClose();
+        }
     }
 
     /**

--- a/src/main/java/ru/digilabs/alkir/rahc/service/RacServicePool.java
+++ b/src/main/java/ru/digilabs/alkir/rahc/service/RacServicePool.java
@@ -10,8 +10,13 @@ import org.springframework.stereotype.Service;
 import ru.digilabs.alkir.rahc.configuration.RasConfigurationProperties;
 import ru.digilabs.alkir.rahc.dto.ConnectionDTO;
 
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.time.Instant;
+import java.util.HexFormat;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -51,6 +56,8 @@ public class RacServicePool {
         var key = buildKey(connection);
         var now = Instant.now();
 
+        evictIfPoolIsFullForNewKey(key);
+
         var pooled = pool.compute(key, (k, existing) -> {
             if (existing != null && !existing.isExpired(now, ttlSeconds)) {
                 existing.updateLastAccess(now);
@@ -62,11 +69,6 @@ public class RacServicePool {
             if (existing != null) {
                 LOGGER.debug("Closing expired RacService for key: {}", k);
                 existing.closeQuietly();
-            }
-
-            // Проверяем размер пула
-            if (pool.size() >= maxPoolSize) {
-                evictOldest();
             }
 
             LOGGER.debug("Creating new RacService for key: {}", k);
@@ -92,6 +94,8 @@ public class RacServicePool {
 
     /**
      * Периодическая очистка устаревших соединений.
+     * Используется best-effort подход: из-за weakly consistent итератора ConcurrentHashMap
+     * соединение может пережить один цикл очистки при конкурентном обновлении/добавлении.
      */
     @Scheduled(fixedDelayString = "${rac.pool.cleanup-interval-ms:60000}")
     public void cleanupExpired() {
@@ -117,22 +121,48 @@ public class RacServicePool {
     /**
      * Вытесняет самое старое соединение из пула.
      */
-    private void evictOldest() {
+    private void evictIfPoolIsFullForNewKey(String key) {
+        while (pool.size() >= maxPoolSize && !pool.containsKey(key)) {
+            if (!evictOldest()) {
+                return;
+            }
+        }
+    }
+
+    private boolean evictOldest() {
         var oldest = pool.entrySet().stream()
             .min((e1, e2) -> e1.getValue().getLastAccess().compareTo(e2.getValue().getLastAccess()))
             .orElse(null);
 
-        if (oldest != null) {
-            LOGGER.debug("Evicting oldest RacService for key: {}", oldest.getKey());
-            pool.remove(oldest.getKey());
-            oldest.getValue().closeQuietly();
+        if (oldest == null) {
+            return false;
         }
+
+        var removed = pool.remove(oldest.getKey());
+        if (removed != null) {
+            LOGGER.debug("Evicting oldest RacService for key: {}", oldest.getKey());
+            removed.closeQuietly();
+            return true;
+        }
+
+        return false;
     }
 
     private String buildKey(ConnectionDTO connection) {
         var props = connection.toConfigurationProperties();
+        var hashedPassword = sha256Hex(props.getClusterAdminPassword());
         return props.getAddress() + ":" + props.getPort() + ":" +
-            props.getClusterAdminUsername() + ":" + props.getClusterAdminPassword();
+            props.getClusterAdminUsername() + ":" + hashedPassword;
+    }
+
+    private String sha256Hex(String value) {
+        try {
+            var digest = MessageDigest.getInstance("SHA-256");
+            var safeValue = Objects.requireNonNullElse(value, "");
+            return HexFormat.of().formatHex(digest.digest(safeValue.getBytes(StandardCharsets.UTF_8)));
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 algorithm is not available", e);
+        }
     }
 
     public int getPoolSize() {
@@ -144,7 +174,7 @@ public class RacServicePool {
      */
     private static class PooledRacService {
         private final RacService racService;
-        private Instant lastAccess;
+        private volatile Instant lastAccess;
 
         PooledRacService(RacService racService, Instant createdAt) {
             this.racService = racService;
@@ -181,7 +211,10 @@ public class RacServicePool {
     /**
      * Обёртка над RacService, которая при close() не закрывает реальное соединение.
      */
-    private static class PooledRacServiceWrapper extends RacService {
+    // Важно: все методы RacService должны явно делегироваться delegate, включая init/close/shutdown,
+    // иначе унаследованная реализация может обратиться к null-полям super(null, null).
+    // Долгосрочно лучше выделить интерфейс для RacService или использовать proxy.
+    private static final class PooledRacServiceWrapper extends RacService {
 
         private final RacService delegate;
 
@@ -198,6 +231,11 @@ public class RacServicePool {
         @Override
         public void init() {
             // Не инициализируем - используем делегат
+        }
+
+        @Override
+        protected void shutdown() {
+            // Не вызываем shutdown базового класса, чтобы не обращаться к null-полям.
         }
 
         // Делегируем все методы к реальному RacService

--- a/src/main/java/ru/digilabs/alkir/rahc/service/RacServiceProvider.java
+++ b/src/main/java/ru/digilabs/alkir/rahc/service/RacServiceProvider.java
@@ -1,9 +1,6 @@
 package ru.digilabs.alkir.rahc.service;
 
-import com._1c.v8.ibis.admin.client.IAgentAdminConnectorFactory;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.ObjectProvider;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 import ru.digilabs.alkir.rahc.configuration.RetryableRacMethod;
 import ru.digilabs.alkir.rahc.dto.ConnectionDTO;
@@ -12,13 +9,17 @@ import ru.digilabs.alkir.rahc.dto.ConnectionDTO;
 @RequiredArgsConstructor
 public class RacServiceProvider {
 
-    @Qualifier("racService")
-    private final ObjectProvider<RacService> racServiceObjectProvider;
-    private final IAgentAdminConnectorFactory factory;
+    private final RacServicePool racServicePool;
 
     @RetryableRacMethod
     public RacService getRacService(ConnectionDTO rasConnection) {
-        var configurationProperties = rasConnection.toConfigurationProperties();
-        return racServiceObjectProvider.getObject(configurationProperties, factory);
+        return racServicePool.getRacService(rasConnection);
+    }
+
+    /**
+     * Инвалидирует соединение в пуле (например, при ошибке).
+     */
+    public void invalidate(ConnectionDTO rasConnection) {
+        racServicePool.invalidate(rasConnection);
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,3 +4,8 @@ springdoc.swagger-ui.operationsSorter=alpha
 springdoc.swagger-ui.tagsSorter=alpha
 springdoc.api-docs.path=/api-docs
 springdoc.show-actuator=true
+
+# RAC connection pool settings
+rac.pool.ttl-seconds=300
+rac.pool.max-size=100
+rac.pool.cleanup-interval-ms=60000


### PR DESCRIPTION
Добавлен `RacServicePool` и интеграция пула в провайдер/обработчики, чтобы переиспользовать подключения к RAC и уменьшить накладные расходы на создание сервисов.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Connection pooling for RAC services with automatic reuse and scheduled cleanup (configurable TTL, max size, cleanup interval).
  * New configuration properties to control pool behavior (defaults: TTL 300s, cleanup interval 60s).
  * Application scheduling enabled to run periodic maintenance tasks.

* **Bug Fixes**
  * Web error handler now active under the web runtime profile for improved web error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->